### PR TITLE
Add login page and route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,18 +1,21 @@
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import ServerList from './components/ServerList';
+import Login from './components/Login';
 
 function App() {
   return (
     <Router>
       <div className="min-h-screen flex flex-col">
         <nav className="navbar bg-base-100 shadow mb-4">
-          <div className="container mx-auto">
+          <div className="container mx-auto flex justify-between">
             <Link to="/" className="btn btn-ghost normal-case text-xl">Velarium</Link>
+            <Link to="/login" className="btn btn-ghost">Login</Link>
           </div>
         </nav>
         <main className="container mx-auto flex-1 p-4">
           <Routes>
             <Route path="/" element={<ServerList />} />
+            <Route path="/login" element={<Login />} />
           </Routes>
         </main>
       </div>

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import axios from 'axios';
+
+export default function Login() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    try {
+      const res = await axios.post('/api/login', { username, password });
+      if (res.data.token) {
+        localStorage.setItem('token', res.data.token);
+      } else {
+        localStorage.setItem('session', 'active');
+      }
+    } catch {
+      setError('Login failed');
+    }
+  };
+
+  return (
+    <div className="max-w-sm mx-auto">
+      <h2 className="text-2xl font-bold mb-4">Login</h2>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="form-control">
+          <label className="label">
+            <span className="label-text">Username</span>
+          </label>
+          <input
+            type="text"
+            className="input input-bordered"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </div>
+        <div className="form-control">
+          <label className="label">
+            <span className="label-text">Password</span>
+          </label>
+          <input
+            type="password"
+            className="input input-bordered"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        {error && <p className="text-error text-sm">{error}</p>}
+        <button type="submit" className="btn btn-primary w-full">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Login` component posting credentials to `/api/login`
- wire up `/login` route and navbar link

## Testing
- `npm test -- --run`
- `pytest` *(fails: ModuleNotFoundError: No module named 'backend')*

------
https://chatgpt.com/codex/tasks/task_e_688ff40629fc833383a71598c0a8fda2