### PR TITLE
Implement DockerManager service for building images

### DIFF
--- a/backend/app/services/docker_manager.py
+++ b/backend/app/services/docker_manager.py
@@ -1,0 +1,78 @@
+
+"""Utilities for interacting with the local Docker daemon."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from typing import Dict, List
+
+import docker
+from docker.errors import APIError, BuildError
+
+
+class DockerManager:
+    """Thin wrapper around the Docker SDK.
+
+    The class currently exposes a :py:meth:`build_image` method which builds a
+    docker image from a given Dockerfile template.  The implementation uses the
+    low level API in order to stream build logs back to the caller.
+    """
+
+    def __init__(self) -> None:  # pragma: no cover - trivial
+        self.client = docker.from_env()
+
+    def build_image(self, template: str, version: str, tag: str) -> List[Dict[str, str]]:
+        """Build a docker image using a template string.
+
+        Parameters
+        ----------
+        template:
+            Dockerfile template containing ``{version}`` placeholder.
+        version:
+            Version string to substitute into the template.
+        tag:
+            Name of the resulting docker image tag.
+
+        Returns
+        -------
+        list of dict
+            Structured build logs returned from the docker daemon.
+
+        Raises
+        ------
+        docker.errors.BuildError
+            If the build fails or the API reports an error.
+        """
+
+        # Assemble the Dockerfile by interpolating the provided version
+        dockerfile_contents = template.format(version=version)
+
+        # Create a tar archive to use as the build context containing only the
+        # Dockerfile.  The Docker SDK expects a file-like object positioned at
+        # the start of the tar stream.
+        fileobj = io.BytesIO()
+        with tarfile.open(fileobj=fileobj, mode="w") as tar:
+            data = dockerfile_contents.encode("utf-8")
+            info = tarfile.TarInfo("Dockerfile")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        fileobj.seek(0)
+
+        try:
+            output = self.client.api.build(
+                fileobj=fileobj,
+                custom_context=True,
+                tag=tag,
+                decode=True,
+            )
+
+            logs: List[Dict[str, str]] = []
+            for chunk in output:
+                logs.append(chunk)
+                if "error" in chunk:
+                    raise BuildError(chunk["error"], build_log=logs)
+            return logs
+        except APIError as exc:  # pragma: no cover - network / docker issues
+            raise BuildError(str(exc), build_log=[]) from exc
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ python-multipart
 pytest
 httpx
 itsdangerous
+docker

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/backend/tests/test_docker_manager.py
+++ b/backend/tests/test_docker_manager.py
@@ -1,0 +1,48 @@
+import tarfile
+import docker
+import pytest
+
+from backend.app.services.docker_manager import DockerManager
+
+
+class DummyClient:
+    def __init__(self, build_func):
+        class API:
+            def __init__(self, func):
+                self._func = func
+
+            def build(self, **kwargs):
+                return self._func(**kwargs)
+
+        self.api = API(build_func)
+
+
+def test_build_image_success(monkeypatch):
+    logs = [{"stream": "ok"}]
+
+    def fake_build(fileobj, custom_context, tag, decode):
+        assert custom_context is True
+        assert tag == "test:latest"
+        assert decode is True
+        fileobj.seek(0)
+        with tarfile.open(fileobj=fileobj, mode="r") as tar:
+            dockerfile = tar.extractfile("Dockerfile").read().decode()
+            assert "123" in dockerfile
+        return iter(logs)
+
+    monkeypatch.setattr(docker, "from_env", lambda: DummyClient(fake_build))
+
+    manager = DockerManager()
+    result = manager.build_image("FROM scratch\nRUN echo {version}\n", "123", "test:latest")
+    assert result == logs
+
+
+def test_build_image_error(monkeypatch):
+    def fake_build(**kwargs):
+        return iter([{ "error": "boom" }])
+
+    monkeypatch.setattr(docker, "from_env", lambda: DummyClient(fake_build))
+
+    manager = DockerManager()
+    with pytest.raises(docker.errors.BuildError):
+        manager.build_image("FROM scratch", "1", "fail")


### PR DESCRIPTION
## Summary
- add DockerManager class wrapping Docker SDK to build images with structured logs
- include docker dependency and tests for success and error paths

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ff6dc3dc48333ab278579dbb94d78