### PR TITLE
Add server Dockerfile templates

### DIFF
--- a/backend/app/templates/fabric/Dockerfile.j2
+++ b/backend/app/templates/fabric/Dockerfile.j2
@@ -1,0 +1,14 @@
+FROM eclipse-temurin:17-jre
+
+ENV EULA=TRUE
+ENV VERSION={{ version }}
+
+WORKDIR /data
+
+RUN curl -L -o server.jar https://meta.fabricmc.net/v2/versions/loader/${VERSION}/latest/server/jar
+
+VOLUME ["/data"]
+
+EXPOSE 25565
+
+CMD ["java", "-Xms1G", "-Xmx1G", "-jar", "server.jar", "nogui"]

--- a/backend/app/templates/forge/Dockerfile.j2
+++ b/backend/app/templates/forge/Dockerfile.j2
@@ -1,0 +1,17 @@
+FROM eclipse-temurin:17-jre
+
+ENV EULA=TRUE
+ENV VERSION={{ version }}
+
+WORKDIR /data
+
+RUN curl -L -o forge-installer.jar https://maven.minecraftforge.net/net/minecraftforge/forge/${VERSION}/forge-${VERSION}-installer.jar \
+    && java -jar forge-installer.jar --installServer \
+    && rm forge-installer.jar \
+    && mv forge-${VERSION}.jar server.jar
+
+VOLUME ["/data"]
+
+EXPOSE 25565
+
+CMD ["java", "-Xms1G", "-Xmx1G", "-jar", "server.jar", "nogui"]

--- a/backend/app/templates/paper/Dockerfile.j2
+++ b/backend/app/templates/paper/Dockerfile.j2
@@ -1,0 +1,14 @@
+FROM eclipse-temurin:17-jre
+
+ENV EULA=TRUE
+ENV VERSION={{ version }}
+
+WORKDIR /data
+
+RUN curl -L -o server.jar https://api.papermc.io/v2/projects/paper/versions/${VERSION}/builds/latest/downloads/paper-${VERSION}.jar
+
+VOLUME ["/data"]
+
+EXPOSE 25565
+
+CMD ["java", "-Xms1G", "-Xmx1G", "-jar", "server.jar", "nogui"]


### PR DESCRIPTION
## Summary
- add Dockerfile templates for Paper, Forge, and Fabric Minecraft servers
- templates install jar for the provided version and expose persistent data volume

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688ff84ca49483339084d92d4bdbc1e9