### PR TITLE
feat: add server build route

### DIFF
--- a/backend/app/routers/servers.py
+++ b/backend/app/routers/servers.py
@@ -1,8 +1,24 @@
 from fastapi import APIRouter, Depends
+from pydantic import BaseModel
 
 from ..auth import require_admin
+from ..services.docker_manager import DockerManager
 
 router = APIRouter(prefix="/servers", dependencies=[Depends(require_admin)])
+
+
+class BuildPayload(BaseModel):
+    template: str
+    version: str
+    tag: str | None = None
+
+
+@router.post("/build")
+def build_server(payload: BuildPayload):
+    manager = DockerManager()
+    tag = payload.tag or "latest"
+    logs = manager.build_image(payload.template, payload.version, tag)
+    return {"logs": logs}
 
 
 @router.get("/")

--- a/backend/tests/test_servers_build.py
+++ b/backend/tests/test_servers_build.py
@@ -1,0 +1,37 @@
+import os
+from fastapi.testclient import TestClient
+
+os.environ["ADMIN_USERNAME"] = "admin"
+os.environ["ADMIN_PASSWORD"] = "secret"
+
+from backend.app.main import app
+from backend.app.services.docker_manager import DockerManager
+
+
+def test_build_server(monkeypatch):
+    logs = [{"stream": "ok"}]
+
+    def fake_build(self, template, version, tag):
+        assert template == "FROM scratch"
+        assert version == "1"
+        assert tag == "test:1"
+        return logs
+
+    monkeypatch.setattr(DockerManager, "__init__", lambda self: None)
+    monkeypatch.setattr(DockerManager, "build_image", fake_build)
+
+    client = TestClient(app)
+    resp = client.post("/login", json={"username": "admin", "password": "secret"})
+    assert resp.status_code == 200
+
+    resp = client.post("/servers/build", json={"template": "FROM scratch", "version": "1", "tag": "test:1"})
+    assert resp.status_code == 200
+    assert resp.json() == {"logs": logs}
+
+
+def test_build_requires_auth(monkeypatch):
+    monkeypatch.setattr(DockerManager, "__init__", lambda self: None)
+    monkeypatch.setattr(DockerManager, "build_image", lambda self, t, v, tag: [])
+    client = TestClient(app)
+    resp = client.post("/servers/build", json={"template": "", "version": ""})
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add build image endpoint for servers
- test server build route auth

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ffa9854cc8333a091a3d6f651fd6f