### PR TITLE
Add Docker image caching with metadata store

### DIFF
--- a/backend/app/routers/servers.py
+++ b/backend/app/routers/servers.py
@@ -17,8 +17,8 @@ class BuildPayload(BaseModel):
 def build_server(payload: BuildPayload):
     manager = DockerManager()
     tag = payload.tag or "latest"
-    logs = manager.build_image(payload.template, payload.version, tag)
-    return {"logs": logs}
+    logs, metadata = manager.build_image(payload.template, payload.version, tag)
+    return {"logs": logs, "metadata": metadata}
 
 
 @router.get("/")

--- a/backend/app/services/docker_manager.py
+++ b/backend/app/services/docker_manager.py
@@ -4,27 +4,33 @@
 from __future__ import annotations
 
 import io
+import json
 import os
 import tarfile
 import tempfile
 import zipfile
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import docker
 import httpx
-from docker.errors import APIError, BuildError
+from docker.errors import APIError, BuildError, ImageNotFound
 
 
 class DockerManager:
-    """Thin wrapper around the Docker SDK.
+    """Thin wrapper around the Docker SDK with simple build caching."""
 
-    The class currently exposes a :py:meth:`build_image` method which builds a
-    docker image from a given Dockerfile template.  The implementation uses the
-    low level API in order to stream build logs back to the caller.
-    """
-
-    def __init__(self) -> None:  # pragma: no cover - trivial
+    def __init__(self, metadata_path: str = "build_metadata.json") -> None:
         self.client = docker.from_env()
+        self.metadata_path = metadata_path
+        if os.path.exists(self.metadata_path):
+            with open(self.metadata_path, "r", encoding="utf-8") as f:
+                self._metadata = json.load(f)
+        else:  # pragma: no cover - trivial
+            self._metadata = {}
+
+    def _save_metadata(self) -> None:
+        with open(self.metadata_path, "w", encoding="utf-8") as f:
+            json.dump(self._metadata, f)
 
     def build_image(
         self,
@@ -33,8 +39,8 @@ class DockerManager:
         tag: str,
         modpack_id: Optional[str] = None,
         source: Optional[str] = None,
-    ) -> List[Dict[str, str]]:
-        """Build a docker image using a template string.
+    ) -> Tuple[List[Dict[str, str]], Dict[str, str]]:
+        """Build a docker image using a template string or return cached metadata.
 
         Parameters
         ----------
@@ -51,14 +57,25 @@ class DockerManager:
 
         Returns
         -------
-        list of dict
-            Structured build logs returned from the docker daemon.
+        tuple
+            ``(logs, metadata)`` where ``logs`` is the structured build logs and
+            ``metadata`` contains information about the built image (currently
+            the image id).
 
         Raises
         ------
         docker.errors.BuildError
             If the build fails or the API reports an error.
         """
+
+        # Check for existing image and short-circuit if present
+        if tag in self._metadata:
+            try:
+                self.client.images.get(tag)
+                return [], self._metadata[tag]
+            except ImageNotFound:
+                del self._metadata[tag]
+                self._save_metadata()
 
         # Assemble the Dockerfile by interpolating the provided version
         dockerfile_contents = template.format(version=version)
@@ -103,7 +120,12 @@ class DockerManager:
                 logs.append(chunk)
                 if "error" in chunk:
                     raise BuildError(chunk["error"], build_log=logs)
-            return logs
+
+            image = self.client.images.get(tag)
+            metadata = {"id": image.id}
+            self._metadata[tag] = metadata
+            self._save_metadata()
+            return logs, metadata
         except APIError as exc:  # pragma: no cover - network / docker issues
             raise BuildError(str(exc), build_log=[]) from exc
 


### PR DESCRIPTION
## Summary
- cache built Docker images by tag and return saved metadata when available
- store image IDs in a JSON metadata file for reuse
- expose cached metadata through the server build endpoint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ffc1748cc83338b4ca9fa0f7d36e8