### PR TITLE
feat: add auth context and route protection

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import ServerList from './components/ServerList';
 import Login from './components/Login';
+import RequireAuth from './components/RequireAuth';
 
 function App() {
   return (
@@ -14,7 +15,7 @@ function App() {
         </nav>
         <main className="container mx-auto flex-1 p-4">
           <Routes>
-            <Route path="/" element={<ServerList />} />
+            <Route path="/" element={<RequireAuth><ServerList /></RequireAuth>} />
             <Route path="/login" element={<Login />} />
           </Routes>
         </main>

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -1,10 +1,14 @@
 import { useState } from 'react';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
 
 export default function Login() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+  const { login } = useAuth();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -12,9 +16,10 @@ export default function Login() {
     try {
       const res = await axios.post('/api/login', { username, password });
       if (res.data.token) {
-        localStorage.setItem('token', res.data.token);
+        login(res.data.token);
+        navigate('/');
       } else {
-        localStorage.setItem('session', 'active');
+        setError('Login failed');
       }
     } catch {
       setError('Login failed');

--- a/frontend/src/components/RequireAuth.tsx
+++ b/frontend/src/components/RequireAuth.tsx
@@ -1,0 +1,12 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+export default function RequireAuth({ children }: { children: JSX.Element }) {
+  const { token } = useAuth();
+
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+interface AuthContextType {
+  token: string | null;
+  login: (token: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem('token'));
+
+  const login = (newToken: string) => {
+    localStorage.setItem('token', newToken);
+    setToken(newToken);
+  };
+
+  const logout = () => {
+    localStorage.removeItem('token');
+    setToken(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+export default AuthContext;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import { AuthProvider } from './context/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add authentication context to track token and session
- guard server list route behind authentication and redirect to login
- allow login form to authenticate and store token

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688ff50be37c833385b18ea4712e9179