### PR TITLE
Add build log tracking and retrieval endpoint

### DIFF
--- a/backend/app/models/build_log.py
+++ b/backend/app/models/build_log.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel
+
+
+class BuildLog(BaseModel):
+    """Record of a server build."""
+
+    tag: str
+    status: str
+    log: Optional[List[Dict[str, str]]] = None
+
+
+# In-memory store of build logs keyed by tag
+build_logs: dict[str, BuildLog] = {}

--- a/backend/app/routers/servers.py
+++ b/backend/app/routers/servers.py
@@ -1,8 +1,10 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
+from docker.errors import BuildError
 
 from ..auth import require_admin
 from ..services.docker_manager import DockerManager
+from ..models.build_log import BuildLog, build_logs
 
 router = APIRouter(prefix="/servers", dependencies=[Depends(require_admin)])
 
@@ -17,8 +19,24 @@ class BuildPayload(BaseModel):
 def build_server(payload: BuildPayload):
     manager = DockerManager()
     tag = payload.tag or "latest"
-    logs, metadata = manager.build_image(payload.template, payload.version, tag)
-    return {"logs": logs, "metadata": metadata}
+    build_logs[tag] = BuildLog(tag=tag, status="building", log=[])
+    try:
+        logs, metadata = manager.build_image(payload.template, payload.version, tag)
+        build_logs[tag].status = "success"
+        build_logs[tag].log = logs
+        return {"logs": logs, "metadata": metadata}
+    except BuildError as exc:
+        build_logs[tag].status = "error"
+        build_logs[tag].log = exc.build_log if hasattr(exc, "build_log") else None
+        raise HTTPException(status_code=500, detail=str(exc))
+
+
+@router.get("/build/{tag}")
+def get_build_log(tag: str):
+    entry = build_logs.get(tag)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Build tag not found")
+    return entry
 
 
 @router.get("/images")

--- a/backend/tests/test_servers_build.py
+++ b/backend/tests/test_servers_build.py
@@ -6,6 +6,8 @@ os.environ["ADMIN_PASSWORD"] = "secret"
 
 from backend.app.main import app
 from backend.app.services.docker_manager import DockerManager
+from backend.app.models.build_log import build_logs
+from docker.errors import BuildError
 
 
 def test_build_server(monkeypatch):
@@ -29,6 +31,54 @@ def test_build_server(monkeypatch):
     )
     assert resp.status_code == 200
     assert resp.json() == {"logs": logs, "metadata": {"id": "imgid"}}
+
+
+def test_get_build_log(monkeypatch):
+    logs = [{"stream": "ok"}]
+
+    def fake_build(self, template, version, tag):
+        return logs, {"id": "imgid"}
+
+    monkeypatch.setattr(DockerManager, "__init__", lambda self: None)
+    monkeypatch.setattr(DockerManager, "build_image", fake_build)
+    build_logs.clear()
+
+    client = TestClient(app)
+    resp = client.post("/login", json={"username": "admin", "password": "secret"})
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/servers/build", json={"template": "FROM scratch", "version": "1", "tag": "test:1"}
+    )
+    assert resp.status_code == 200
+
+    resp = client.get("/servers/build/test:1")
+    assert resp.status_code == 200
+    assert resp.json() == {"tag": "test:1", "status": "success", "log": logs}
+
+
+def test_build_log_failure(monkeypatch):
+    logs = [{"stream": "err"}]
+
+    def fake_build(self, template, version, tag):
+        raise BuildError("fail", build_log=logs)
+
+    monkeypatch.setattr(DockerManager, "__init__", lambda self: None)
+    monkeypatch.setattr(DockerManager, "build_image", fake_build)
+    build_logs.clear()
+
+    client = TestClient(app)
+    resp = client.post("/login", json={"username": "admin", "password": "secret"})
+    assert resp.status_code == 200
+
+    resp = client.post(
+        "/servers/build", json={"template": "FROM scratch", "version": "1", "tag": "test:1"}
+    )
+    assert resp.status_code == 500
+
+    resp = client.get("/servers/build/test:1")
+    assert resp.status_code == 200
+    assert resp.json() == {"tag": "test:1", "status": "error", "log": logs}
 
 
 def test_build_requires_auth(monkeypatch):


### PR DESCRIPTION
## Summary
- add BuildLog model and in-memory storage
- track build status and logs
- add `GET /servers/build/{tag}` endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68900450819c8333ba03552f17eedac0