### PR TITLE
Add async API and Docker build tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,41 @@
 import os
 import sys
+import io
+import zipfile
+
+import pytest
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
+
+
+@pytest.fixture
+def template_dir(tmp_path):
+    """Create a temporary directory containing a sample Dockerfile template."""
+
+    path = tmp_path / "templates"
+    path.mkdir()
+    (path / "Dockerfile").write_text("FROM scratch\nRUN echo {version}\n", encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def modpack_metadata():
+    """Return archive bytes and metadata for a dummy modpack."""
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("mods/mod.jar", b"mod")
+        zf.writestr("config/conf.yml", b"cfg")
+    buf.seek(0)
+    archive = buf.read()
+    metadata = [{"files": [{"url": "https://download"}]}]
+    return archive, metadata
+
+
+@pytest.fixture(scope="session")
+def anyio_backend():  # pragma: no cover - configuration for anyio tests
+    """Use asyncio backend for httpx.AsyncClient tests."""
+    return "asyncio"
+

--- a/backend/tests/test_servers_async.py
+++ b/backend/tests/test_servers_async.py
@@ -1,0 +1,122 @@
+import os
+import pytest
+from httpx import AsyncClient, ASGITransport
+from docker.errors import BuildError
+
+os.environ["ADMIN_USERNAME"] = "admin"
+os.environ["ADMIN_PASSWORD"] = "secret"
+os.environ["ANYIO_BACKEND"] = "asyncio"
+
+from backend.app.main import app
+from backend.app.services.docker_manager import DockerManager
+from backend.app.models.build_log import build_logs
+
+
+@pytest.mark.anyio("asyncio")
+async def test_build_and_log(monkeypatch):
+    logs = [{"stream": "ok"}]
+
+    monkeypatch.setattr(DockerManager, "__init__", lambda self: None)
+    monkeypatch.setattr(
+        DockerManager, "build_image", lambda self, t, v, tag: (logs, {"id": "imgid"})
+    )
+    build_logs.clear()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/login", json={"username": "admin", "password": "secret"}
+        )
+        assert resp.status_code == 200
+
+        resp = await client.post(
+            "/servers/build",
+            json={"template": "FROM scratch", "version": "1", "tag": "test:1"},
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get("/servers/build/test:1")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "success"
+        assert data["log"] == logs
+
+
+@pytest.mark.anyio("asyncio")
+async def test_build_error_handling(monkeypatch):
+    logs = [{"stream": "err"}]
+
+    def fail_build(self, t, v, tag):
+        raise BuildError("fail", build_log=logs)
+
+    monkeypatch.setattr(DockerManager, "__init__", lambda self: None)
+    monkeypatch.setattr(DockerManager, "build_image", fail_build)
+    build_logs.clear()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/login", json={"username": "admin", "password": "secret"}
+        )
+        assert resp.status_code == 200
+
+        resp = await client.post(
+            "/servers/build",
+            json={"template": "FROM scratch", "version": "1", "tag": "test:1"},
+        )
+        assert resp.status_code == 500
+
+        resp = await client.get("/servers/build/test:1")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "error"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_get_build_log_not_found(monkeypatch):
+    monkeypatch.setattr(DockerManager, "__init__", lambda self: None)
+    build_logs.clear()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/login", json={"username": "admin", "password": "secret"}
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get("/servers/build/missing")
+        assert resp.status_code == 404
+
+
+@pytest.mark.anyio("asyncio")
+async def test_list_images(monkeypatch):
+    images = [{"tag": "repo:tag", "template": "paper", "version": "1", "built": "123"}]
+
+    monkeypatch.setattr(DockerManager, "__init__", lambda self: None)
+    monkeypatch.setattr(DockerManager, "list_images", lambda self: images)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.post(
+            "/login", json={"username": "admin", "password": "secret"}
+        )
+        assert resp.status_code == 200
+
+        resp = await client.get("/servers/images")
+        assert resp.status_code == 200
+        assert resp.json() == {"images": images}
+
+
+@pytest.mark.anyio("asyncio")
+async def test_requires_auth(monkeypatch):
+    monkeypatch.setattr(DockerManager, "__init__", lambda self: None)
+    monkeypatch.setattr(DockerManager, "list_images", lambda self: [])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        resp = await client.get("/servers/images")
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- add reusable fixtures for templates, modpack metadata, and async backend
- expand Docker manager tests for build, modpack extraction and caching
- create async API tests using `httpx.AsyncClient` to verify responses and errors

## Testing
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68900574136c83339896cd9a5b3b95f4