### PR TITLE
feat: list available servers

### DIFF
--- a/frontend/src/components/ServerList.tsx
+++ b/frontend/src/components/ServerList.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import axios from 'axios';
 
 interface Server {
-  id: number;
+  id: string;
   name: string;
   status: string;
 }
@@ -11,7 +11,10 @@ export default function ServerList() {
   const [servers, setServers] = useState<Server[]>([]);
 
   useEffect(() => {
-    axios.get('/api/servers').then((res) => setServers(res.data)).catch(() => setServers([]));
+    axios
+      .get('/api/servers')
+      .then((res) => setServers(res.data.servers ?? []))
+      .catch(() => setServers([]));
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- add docker-backed server listing endpoint
- adjust front-end to handle `servers` response shape

## Testing
- `pytest` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689007b7af2883339575f84dc75c96b5